### PR TITLE
Update and rename Int.php to Integer.php

### DIFF
--- a/Model/Core/Attribute/Type/Integer.php
+++ b/Model/Core/Attribute/Type/Integer.php
@@ -17,7 +17,7 @@
  */
 namespace Umc\Base\Model\Core\Attribute\Type;
 
-class Int extends AbstractType
+class Integer extends AbstractType
 {
 
 }


### PR DESCRIPTION
FIX: PHP Fatal error: Cannot use 'Int' as class name as it is reserved in /app/code/Umc/Base/Model/Core/Attribute/Type/Int.php on line 20