### PR TITLE
Update Decimal.php

### DIFF
--- a/Model/Core/Attribute/Type/Decimal.php
+++ b/Model/Core/Attribute/Type/Decimal.php
@@ -17,7 +17,7 @@
  */
 namespace Umc\Base\Model\Core\Attribute\Type;
 
-class Decimal extends Int
+class Decimal extends Integer
 {
 
 }


### PR DESCRIPTION
Fix: PHP Fatal error: Cannot use 'Int' as class name as it is reserved in /app/code/Umc/Base/Model/Core/Attribute/Type/Int.php on line 20